### PR TITLE
Andrew Chen - sudoku implementation + tests

### DIFF
--- a/sudoku.go
+++ b/sudoku.go
@@ -1,1 +1,101 @@
 package main
+
+import (
+	"errors"
+)
+
+const (
+	// BOARD_SIZE represents the size of the Sudoku board.
+	BOARD_SIZE = 9
+	// SMALL_SQUARE_SIZE represents the size of each small square in the Sudoku board.
+	SMALL_SQUARE_SIZE = 3
+)
+
+// Position stores the row and column of a position in the board.
+type Position struct {
+	row int
+	col int
+}
+
+// SolveSudoku solves a Sudoku puzzle and returns the solved board.
+func SolveSudoku(board [][]int) [][]int {
+	board, _ = SolveSudokuHelper(board, Position{0, 0})
+	return board
+}
+
+// SolveSudokuHelper is a recursive helper function for solving Sudoku.
+// It explores possible values for each unfilled position and backtracks if necessary.
+func SolveSudokuHelper(board [][]int, curPosition Position) ([][]int, error) {
+	nextUnfilled, err := nextUnfilled(board, curPosition)
+	if err != nil {
+		return board, nil
+	}
+	for value := 1; value <= 9; value++ {
+		validValue := isValuePlaceable(board, nextUnfilled, value)
+		if validValue {
+			boardWithValue := deepCopy2DSlice(board)
+			boardWithValue[nextUnfilled.row][nextUnfilled.col] = value
+			newBoard, err := SolveSudokuHelper(boardWithValue, nextUnfilled)
+			if err == nil {
+				return newBoard, nil
+			}
+		}
+	}
+	return board, errors.New("no valid board states found")
+}
+
+// deepCopy2DSlice creates a deep copy of a 2D slice.
+func deepCopy2DSlice(board [][]int) [][]int {
+	boardWithValue := make([][]int, len(board))
+	for i := range board {
+		boardWithValue[i] = make([]int, len(board[i]))
+		copy(boardWithValue[i], board[i])
+	}
+	return boardWithValue
+}
+
+// nextUnfilled finds the next unfilled position in the Sudoku board.
+func nextUnfilled(board [][]int, curPosition Position) (Position, error) {
+	for col := curPosition.col; col < BOARD_SIZE; col++ {
+		if board[curPosition.row][col] == 0 {
+			return Position{curPosition.row, col}, nil
+		}
+	}
+	curPosition.row++
+	for row := curPosition.row; row < BOARD_SIZE; row++ {
+		for col := 0; col < BOARD_SIZE; col++ {
+			if board[row][col] == 0 {
+				return Position{row, col}, nil
+			}
+		}
+	}
+	return Position{}, errors.New("no next unfilled")
+}
+
+// isValuePlaceable checks if a value can be placed at a given position in the Sudoku board.
+func isValuePlaceable(board [][]int, testingPos Position, value int) bool {
+	// Check if the column of the position already has the value.
+	for row := 0; row < BOARD_SIZE; row++ {
+		if board[row][testingPos.col] == value {
+			return false
+		}
+	}
+	// Check if the row of the position already has the value.
+	for col := 0; col < BOARD_SIZE; col++ {
+		if board[testingPos.row][col] == value {
+			return false
+		}
+	}
+	// Check if the small square of the position already has the value.
+	startRow := testingPos.row - testingPos.row%SMALL_SQUARE_SIZE
+	startCol := testingPos.col - testingPos.col%SMALL_SQUARE_SIZE
+	for row := startRow; row < startRow+SMALL_SQUARE_SIZE; row++ {
+		for col := startCol; col < startCol+SMALL_SQUARE_SIZE; col++ {
+			if board[row][col] == value {
+				return false
+			}
+		}
+	}
+	// If it's in none of them, then this placement is valid.
+	return true
+}

--- a/sudoku_test.go
+++ b/sudoku_test.go
@@ -5,9 +5,18 @@ import (
 	"testing"
 )
 
-func TestSolveSudoku(t *testing.T) {
+func TestNextUnfilled(t *testing.T) {
+	runTest := func(testName string, input [][]int, startPos Position, expectedPos Position, expectedError bool) {
+		t.Run(testName, func(t *testing.T) {
+			solved, err := nextUnfilled(input, startPos)
+			if (err != nil) != expectedError || (err == nil && solved != expectedPos) {
+				t.Errorf("%s: Sudoku puzzle was not solved correctly. Expected:\n%v\n\nGot:\n%v", testName, expectedPos, solved)
+			}
+		})
+	}
+
 	input := [][]int{
-		{5, 3, 0, 0, 7, 0, 0, 0, 0},
+		{5, 3, 0, 0, 7, 0, 0, 0, 9},
 		{6, 0, 0, 1, 9, 5, 0, 0, 0},
 		{0, 9, 8, 0, 0, 0, 0, 6, 0},
 		{8, 0, 0, 0, 6, 0, 0, 0, 3},
@@ -18,21 +27,72 @@ func TestSolveSudoku(t *testing.T) {
 		{0, 0, 0, 0, 8, 0, 0, 7, 9},
 	}
 
-	expected := [][]int{
-		{5, 3, 4, 6, 7, 8, 9, 1, 2},
-		{6, 7, 2, 1, 9, 5, 3, 4, 8},
-		{1, 9, 8, 3, 4, 2, 5, 6, 7},
-		{8, 5, 9, 7, 6, 1, 4, 2, 3},
-		{4, 2, 6, 8, 5, 3, 7, 9, 1},
-		{7, 1, 3, 9, 2, 4, 8, 5, 6},
-		{9, 6, 1, 5, 3, 7, 2, 8, 4},
-		{2, 8, 7, 4, 1, 9, 6, 3, 5},
-		{3, 4, 5, 2, 8, 6, 1, 7, 9},
+	runTest("Typical use case", input, Position{0, 0}, Position{0, 2}, false)
+	runTest("Starting on an unfilled tile", input, Position{0, 3}, Position{0, 3}, false)
+	runTest("Next unfilled tile is on the next line", input, Position{0, 8}, Position{1, 1}, false)
+	runTest("No next tile, should error", input, Position{8, 8}, Position{0, 0}, true)
+}
+
+func TestIsValuePlacable(t *testing.T) {
+	runTest := func(testName string, board [][]int, testingPos Position, value int, expected bool) {
+		t.Run(testName, func(t *testing.T) {
+			if result := isValuePlaceable(board, testingPos, value); result != expected {
+				t.Errorf("%s: Expected placement to be %t, but got %t.", testName, expected, result)
+			}
+		})
+	}
+	board := [][]int{
+		{1, 0, 0, 0, 0, 0, 0, 0, 0},
+		{0, 2, 0, 0, 0, 0, 0, 0, 0},
+		{0, 0, 3, 0, 0, 0, 0, 0, 0},
+		{0, 0, 0, 4, 0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 5, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0, 6, 0, 0, 0},
+		{0, 0, 0, 0, 0, 0, 7, 0, 0},
+		{0, 0, 0, 0, 0, 0, 0, 8, 0},
+		{0, 0, 0, 0, 0, 0, 0, 0, 9},
+	}
+	runTest("Invalid placement in the same column", board, Position{3, 1}, 1, true)
+	runTest("Invalid placement in the same row", board, Position{0, 3}, 1, false)
+	runTest("Invalid placement in the same small square", board, Position{2, 1}, 1, false)
+	runTest("valid placement", board, Position{7, 8}, 1, true)
+}
+
+type BoardTest struct {
+	input    [][]int
+	expected [][]int
+}
+
+func TestSolveSudoku(t *testing.T) {
+	boards := []BoardTest{
+		{[][]int{
+			{5, 3, 0, 0, 7, 0, 0, 0, 0},
+			{6, 0, 0, 1, 9, 5, 0, 0, 0},
+			{0, 9, 8, 0, 0, 0, 0, 6, 0},
+			{8, 0, 0, 0, 6, 0, 0, 0, 3},
+			{4, 0, 0, 8, 0, 3, 0, 0, 1},
+			{7, 0, 0, 0, 2, 0, 0, 0, 6},
+			{0, 6, 0, 0, 0, 0, 2, 8, 0},
+			{0, 0, 0, 4, 1, 9, 0, 0, 5},
+			{0, 0, 0, 0, 8, 0, 0, 7, 9},
+		},
+			[][]int{
+				{5, 3, 4, 6, 7, 8, 9, 1, 2},
+				{6, 7, 2, 1, 9, 5, 3, 4, 8},
+				{1, 9, 8, 3, 4, 2, 5, 6, 7},
+				{8, 5, 9, 7, 6, 1, 4, 2, 3},
+				{4, 2, 6, 8, 5, 3, 7, 9, 1},
+				{7, 1, 3, 9, 2, 4, 8, 5, 6},
+				{9, 6, 1, 5, 3, 7, 2, 8, 4},
+				{2, 8, 7, 4, 1, 9, 6, 3, 5},
+				{3, 4, 5, 2, 8, 6, 1, 7, 9},
+			}},
+	}
+	for _, test := range boards {
+		solved := SolveSudoku(test.input)
+		if !reflect.DeepEqual(solved, test.expected) {
+			t.Errorf("Sudoku puzzle was not solved correctly. Expected:\n%v\n\nGot:\n%v", test.expected, solved)
+		}
 	}
 
-	solved := SolveSudoku(input)
-
-	if !reflect.DeepEqual(solved, expected) {
-		t.Errorf("Sudoku puzzle was not solved correctly. Expected:\n%v\n\nGot:\n%v", expected, solved)
-	}
 }


### PR DESCRIPTION
I implemented a simple backtracking solution for sudoku. The worst-case time complexity is still exponential, but in practice it's much less than a naïve solution of generating every possible board. 

1. Scan through the board until you reach an unfilled slot
2. Determine all possible values that can go into the slot with current board state
3. For each of the possible values, start scanning again starting from that slot to find the next unfilled slot, and repeat.
4. Eventually, there will be one valid board, with all other possibilities running into situations where none of the values will slot into a specific unfilled slot. 

Unit tests for my helper functions are included in sudoku_test.go, and the existing sudoku test was moved into an array to make it easier to add mores tests. Basic Godoc comments included as well.

Happy reading! 
